### PR TITLE
Add .gitignore for project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Node dependencies
+node_modules/
+
+# Build output
+out/
+dist/
+build/
+
+# Electron packaging
+*.exe
+*.asar
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.log
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# SQLite database files
+*.sqlite
+*.sqlite3
+*.db
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE/editor files
+.vscode/
+.idea/


### PR DESCRIPTION
Added a root-level .gitignore file configured for the project.

This ignores:
- node_modules
- build and dist output
- packaged Electron files (.exe, .asar)
- SQLite database files
- environment files (.env)
- IDE/editor folders (.vscode, .idea)
- log files

Resolves Issue #8.
