### PR TITLE
Issue #29: add calendar grid view

### DIFF
--- a/backend/src/calendar_app/app.py
+++ b/backend/src/calendar_app/app.py
@@ -1,9 +1,3 @@
-#app.py
-# This does the initiliazation and execution of the application
-# Uses Flask for it all.
-# Important note: Serves as the primary backend service for the the application
-# Delivers frontend pages as well.
-
 from flask import Flask, render_template
 
 def create_app():
@@ -18,6 +12,11 @@ def create_app():
     @app.route("/calendar")
     def calendar_view():
         return render_template("calendar.html")
+
+    # Calendar grid route
+    @app.route("/calendar/grid")
+    def calendar_grid_view():
+        return render_template("calendar_grid.html")
 
     return app
 

--- a/backend/src/calendar_app/static/calendar_background.js
+++ b/backend/src/calendar_app/static/calendar_background.js
@@ -1,0 +1,29 @@
+(function () {
+  const select = document.getElementById("calendarBackground");
+  if (!select) return;
+
+    const presets = {
+  default:  { bg: "#f6f7fb", img: "none" },
+  soft:     { bg: "#e2e6ef", img: "none" },  
+  blue:     { bg: "#cfe8ff", img: "none" },  
+  pink:     { bg: "#ffd1dc", img: "none" },
+  green:    { bg: "#d1f7d6", img: "none" },
+  red:      { bg: "#ffd6d6", img: "none" }, 
+};
+
+
+  function applyPreset(key) {
+    const preset = presets[key] || presets.default;
+    document.documentElement.style.setProperty("--calendar-bg", preset.bg);
+    document.documentElement.style.setProperty("--calendar-bg-image", preset.img);
+  }
+
+  const saved = localStorage.getItem("calendarBackground") || "default";
+  select.value = saved;
+  applyPreset(saved);
+
+  select.addEventListener("change", () => {
+    localStorage.setItem("calendarBackground", select.value);
+    applyPreset(select.value);
+  });
+})();

--- a/backend/src/calendar_app/static/calendar_grid.css
+++ b/backend/src/calendar_app/static/calendar_grid.css
@@ -1,0 +1,24 @@
+.cal-header{display:flex;align-items:center;gap:10px;margin-bottom:12px}
+.month-label{margin:0;font-size:1.25rem;font-weight:800}
+.spacer{flex:1}
+.btn{border:1px solid #e5e7eb;background:#fff;padding:8px 10px;border-radius:10px;cursor:pointer}
+.weekday-row{display:grid;grid-template-columns:repeat(7,1fr);margin-bottom:6px}
+.weekday{text-align:center;font-size:.85rem;color:#6b7280;padding:8px 0}
+.month-grid{display:grid;grid-template-columns:repeat(7,1fr);border:1px solid #e5e7eb;border-radius:14px;overflow:hidden;background:#fff}
+.day{min-height:110px;padding:10px;border-right:1px solid #e5e7eb;border-bottom:1px solid #e5e7eb;cursor:pointer}
+.day:nth-child(7n){border-right:none}
+.day.outside{background:#fafafa;color:#9ca3af}
+.day.today .day-number{color:#2563eb}
+.day-header{display:flex;justify-content:space-between;margin-bottom:8px}
+.day-number{font-weight:800;font-size:.95rem}
+.chips{display:flex;flex-direction:column;gap:6px}
+.chip{background:#f3f4f6;border:1px solid #e5e7eb;border-radius:10px;padding:6px 8px;font-size:.82rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.more{font-size:.8rem;color:#6b7280;padding:4px 2px}
+.details{margin-top:14px;border:1px solid #e5e7eb;border-radius:14px;background:#fff;padding:12px}
+.details-title{margin:0 0 8px;font-size:1rem}
+.details-body{font-size:.95rem;white-space:pre-line}
+.day.today .day-number{background:#2563eb;color:white;border-radius:999px;padding:2px 8px;display:inline-block;}
+.day:hover { background:#f8fafc; }
+.day.selected {outline: 2px solid #2563eb;outline-offset: -2px;border-radius: 12px;}
+
+

--- a/backend/src/calendar_app/static/calendar_grid.js
+++ b/backend/src/calendar_app/static/calendar_grid.js
@@ -1,0 +1,182 @@
+(() => {
+  const gridEl = document.getElementById("grid");
+  const monthLabelEl = document.getElementById("monthLabel");
+  const detailsBodyEl = document.getElementById("detailsBody");
+  const prevBtn = document.getElementById("prevBtn");
+  const nextBtn = document.getElementById("nextBtn");
+  const todayBtn = document.getElementById("todayBtn");
+
+  const pad2 = (n) => String(n).padStart(2, "0");
+  const toISO = (d) =>
+    `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+
+  const startDay = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
+  const addDays = (d, n) => {
+    const x = new Date(d);
+    x.setDate(x.getDate() + n);
+    return x;
+  };
+
+  const startOfWeek = (d) => addDays(startDay(d), -d.getDay()); // Sunday
+  const startOfMonth = (y, m) => new Date(y, m, 1);
+
+  const monthLabel = (y, m) =>
+    new Date(y, m, 1).toLocaleString(undefined, { month: "long" }) + ` ${y}`;
+
+  const today = startDay(new Date());
+  let viewY = today.getFullYear();
+  let viewM = today.getMonth();
+
+  // Mock events for now
+  const mockEvents = [
+    { id: 1, title: "Team meeting", date: "2026-03-03", startTime: "10:00" },
+    { id: 2, title: "Study block", date: "2026-03-03", startTime: "18:00" },
+    { id: 3, title: "Project work", date: "2026-03-08", startTime: "14:30" },
+  ];
+
+  function buildEventMap(list) {
+    const map = new Map();
+    for (const ev of list) {
+      if (!map.has(ev.date)) map.set(ev.date, []);
+      map.get(ev.date).push(ev);
+    }
+    for (const [k, arr] of map.entries()) {
+      arr.sort((a, b) => (a.startTime || "").localeCompare(b.startTime || ""));
+      map.set(k, arr);
+    }
+    return map;
+  }
+
+  const eventsByDay = buildEventMap(mockEvents);
+
+  function clearSelectedDay() {
+    document
+      .querySelectorAll(".day.selected")
+      .forEach((el) => el.classList.remove("selected"));
+  }
+
+  function renderDayDetails(iso) {
+    const dayEvents = eventsByDay.get(iso) || [];
+    detailsBodyEl.textContent = dayEvents.length
+      ? `${iso}\n` +
+        dayEvents
+          .map((ev) =>
+            `• ${(ev.startTime || "").trim()} ${ev.title || "Untitled"}`.trim()
+          )
+          .join("\n")
+      : `${iso}: No events.`;
+  }
+
+  function render() {
+    gridEl.innerHTML = "";
+    monthLabelEl.textContent = monthLabel(viewY, viewM);
+
+    const first = startOfWeek(startOfMonth(viewY, viewM));
+    const cells = 42;
+
+    for (let i = 0; i < cells; i++) {
+      const d = addDays(first, i);
+      const iso = toISO(d);
+      const inMonth = d.getMonth() === viewM;
+
+      const dayEl = document.createElement("div");
+      dayEl.className =
+        "day" +
+        (inMonth ? "" : " outside") +
+        (iso === toISO(today) ? " today" : "");
+
+      const header = document.createElement("div");
+      header.className = "day-header";
+
+      const num = document.createElement("div");
+      num.className = "day-number";
+      num.textContent = String(d.getDate());
+      header.appendChild(num);
+
+      const chips = document.createElement("div");
+      chips.className = "chips";
+
+      const evs = eventsByDay.get(iso) || [];
+      const maxShow = 3;
+
+      evs.slice(0, maxShow).forEach((ev) => {
+        const chip = document.createElement("div");
+        chip.className = "chip";
+        chip.title = ev.title || "Untitled";
+        chip.textContent = ev.startTime
+          ? `${ev.startTime} ${ev.title}`
+          : ev.title || "Untitled";
+
+        chip.addEventListener("click", (e) => {
+          e.stopPropagation();
+          clearSelectedDay();
+          dayEl.classList.add("selected");
+          detailsBodyEl.textContent = `${iso}\n• ${(ev.startTime || "")
+            .trim()} ${ev.title || "Untitled"}`.trim();
+        });
+
+        chips.appendChild(chip);
+      });
+
+      if (evs.length > maxShow) {
+        const more = document.createElement("div");
+        more.className = "more";
+        more.textContent = `+${evs.length - maxShow} more`;
+
+        more.addEventListener("click", (e) => {
+          e.stopPropagation();
+          clearSelectedDay();
+          dayEl.classList.add("selected");
+          renderDayDetails(iso);
+        });
+
+        chips.appendChild(more);
+      }
+
+      dayEl.appendChild(header);
+      dayEl.appendChild(chips);
+
+      dayEl.addEventListener("click", () => {
+        clearSelectedDay();
+        dayEl.classList.add("selected");
+        renderDayDetails(iso);
+      });
+
+      gridEl.appendChild(dayEl);
+    }
+
+    const todayCell = gridEl.querySelector(".day.today");
+    if (todayCell) {
+      clearSelectedDay();
+      todayCell.classList.add("selected");
+      renderDayDetails(toISO(today));
+    }
+  }
+
+  prevBtn.addEventListener("click", () => {
+    viewM--;
+    if (viewM < 0) {
+      viewM = 11;
+      viewY--;
+    }
+    render();
+  });
+
+  nextBtn.addEventListener("click", () => {
+    viewM++;
+    if (viewM > 11) {
+      viewM = 0;
+      viewY++;
+    }
+    render();
+  });
+
+  todayBtn.addEventListener("click", () => {
+    viewY = today.getFullYear();
+    viewM = today.getMonth();
+    render();
+  });
+
+  render();
+})();

--- a/backend/src/calendar_app/templates/base.html
+++ b/backend/src/calendar_app/templates/base.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>{% block title %}Day-2-Day{% endblock %}</title>
+
+    {% block head %}{% endblock %}
 </head>
 
 <body style="margin:0; font-family: Arial, sans-serif; background-color:#f5f6f8;">
@@ -29,5 +31,6 @@
 
 </div>
 
+{% block scripts %}{% endblock %}
 </body>
 </html>

--- a/backend/src/calendar_app/templates/calendar.html
+++ b/backend/src/calendar_app/templates/calendar.html
@@ -1,14 +1,35 @@
 {% extends "base.html" %}
-
 {% block title %}Calendar{% endblock %}
 
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='calendar_grid.css') }}">
+{% endblock %}
+
 {% block content %}
+<div>
+  <div class="cal-header">
+    <button id="prevBtn" class="btn" type="button">←</button>
+    <h2 id="monthLabel" class="month-label">Month YYYY</h2>
+    <button id="nextBtn" class="btn" type="button">→</button>
+    <div class="spacer"></div>
+    <button id="todayBtn" class="btn" type="button">Today</button>
+  </div>
 
-<h2>Calendar View</h2>
-<p>This is a placeholder calendar for your prototype.</p>
-<ul>
-    <li>Jan 30 – C346 Proposal</li>
-    <li>Feb 2 – Canvas API Research</li>
-</ul>
+  <div class="weekday-row">
+    <div class="weekday">Sun</div><div class="weekday">Mon</div><div class="weekday">Tue</div>
+    <div class="weekday">Wed</div><div class="weekday">Thu</div><div class="weekday">Fri</div>
+    <div class="weekday">Sat</div>
+  </div>
 
+  <div id="grid" class="month-grid"></div>
+
+  <div class="details">
+    <h3 class="details-title">Selected Day</h3>
+    <div id="detailsBody" class="details-body">Click a day to view events.</div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='calendar_grid.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Changes

Calendar page now renders a 7×6 month grid with:

Prev / Next month navigation

Today button

Highlight for today

Click-to-select day (selected outline)

Event “chips” rendered in day cells (mock data for now)

“+N more” indicator when a day has more than 3 events

Clicking a day updates the “Selected Day” details

Clicking an event chip shows that event in details