### PR TITLE
Add custom assignment creation endpoint

### DIFF
--- a/backend/src/calendar_app/__main__.py
+++ b/backend/src/calendar_app/__main__.py
@@ -1,8 +1,11 @@
 from fastapi import FastAPI
 from calendar_app.api.hello_api import router as hello_router
+from calendar_app.api.assignments import router as assignments_router
 
 app = FastAPI()
+
 app.include_router(hello_router, prefix="/api")
+app.include_router(assignments_router)
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/src/calendar_app/api/assignments.py
+++ b/backend/src/calendar_app/api/assignments.py
@@ -12,6 +12,11 @@ ASSIGNMENTS = [
     Assignment(name="Assignment 1", description="Show all work")
 ]
 
-@router.get("/assignments", response_model=List[Assignment])
+@router.get("", response_model=List[Assignment])
 def list_assignments():
     return ASSIGNMENTS
+
+@router.post("", response_model=Assignment)
+def create_assignment(assignment: Assignment):
+    ASSIGNMENTS.append(assignment)
+    return assignment


### PR DESCRIPTION
Added support for custom assignment creation in the assignments API.

Changes made:
- kept existing GET /assignments endpoint
- added POST /assignments endpoint
- registered assignments router in the FastAPI app

Tested:
- GET /assignments returns assignment list
- POST /assignments successfully creates a new assignment
- verified new assignment appears in GET response